### PR TITLE
Reads compressed files

### DIFF
--- a/R/reader.R
+++ b/R/reader.R
@@ -21,7 +21,7 @@ readFitFile <- function(fileName) {
 #' @importFrom methods is new
 .readFile <- function(fileName, preallocate = TRUE) {
   
-  con <- file(fileName, "rb")
+  con <- gzfile(fileName, "rb")
   on.exit(close(con))
   file_header <- .readFileHeader(con)
   


### PR DESCRIPTION
Use gzfile instead of file. gzfile opens compressed and uncompressed files. Downloading from Strava in bulk, sometimes the file comes as a gz compressed file.