### PR TITLE
address failure loading Zwift .fit file exports

### DIFF
--- a/R/dataFormatting.R
+++ b/R/dataFormatting.R
@@ -273,6 +273,10 @@
     ) 
   )
 
+  if(ncol(message_table) == 0) {
+    return(NULL)
+  }
+  
   for(i in ncol(message_table)) {
     attributes(message_table[[i]]) <- list(units = units[i])
   }


### PR DESCRIPTION
When loading .fit files exported directly from Zwift (via the website), they reliably fail on .processDevFieldsList(). I am not an expert in the .fit file structure, but this fix solves the issue.